### PR TITLE
Increase the clickable area of star image

### DIFF
--- a/app/src/main/res/layout/message_list_element.xml
+++ b/app/src/main/res/layout/message_list_element.xml
@@ -52,6 +52,7 @@
         android:layout_height="wrap_content"
         android:text="03.09.16, 17:18"
         android:textSize="@dimen/material_text_caption"
+        android:layout_marginLeft="16dp"
         android:layout_alignParentTop="true"
         android:layout_alignParentRight="true" />
 
@@ -60,8 +61,9 @@
         android:layout_below="@+id/msg_date"
         android:layout_alignParentBottom="true"
         android:layout_alignParentRight="true"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginLeft="16dp" />
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:paddingTop="16dp"
+        android:paddingLeft="16dp" />
 
 </RelativeLayout>


### PR DESCRIPTION
Увеличил размер нажимаемой области вокруг звездочки в списке. А то сейчас нужно очень точно целится.

И сделал небольшой отступ заголовка от даты, что бы не сливались в одно целое.
